### PR TITLE
Improve mod compatibility by converting patch from prefix to transpiler

### DIFF
--- a/Source/Dynamic_Carrying_Capacity_Patch/Dynamic_Carrying_Capacity.cs
+++ b/Source/Dynamic_Carrying_Capacity_Patch/Dynamic_Carrying_Capacity.cs
@@ -12,7 +12,5 @@ public static class Dynamic_Carrying_Capacity
     static Dynamic_Carrying_Capacity()
     {
         new Harmony("yemg.rimworld").PatchAll(Assembly.GetExecutingAssembly());
-
-        CheckVehicles = ModLister.GetActiveModWithIdentifier("SmashPhil.VehicleFramework") != null;
     }
 }

--- a/Source/Dynamic_Carrying_Capacity_Patch/MassUtility_Capacity_Patch.cs
+++ b/Source/Dynamic_Carrying_Capacity_Patch/MassUtility_Capacity_Patch.cs
@@ -1,9 +1,7 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Reflection.Emit;
-using System.Text;
 using HarmonyLib;
 using RimWorld;
 using Verse;


### PR DESCRIPTION
The current implementation of this mod makes it incompatible with the `VEF_MassCarryCapacity` `StatDef` included in the Vanilla Expanded Framework. Their framework uses a Harmony Transpiler on `MassUtility.CarryCapacity` to modify a pawn's carrying capacity. Because this mod uses a Harmony Prefix to replace that method with a custom implementation, the changes made by the Vanilla Expanded Framework (and any other mods using transpilers on that method) are never used. This means that all items in Vanilla Expanded mods which are intended to provide a carrying capacity bonus do not function while this mod is active.

I've removed the prefix entirely and replaced it with a transpiler that replaces the default `Pawn.BodySize * 35` formula with the more complex calculation from this mod's original author.

The compatibility check for the Vehicles Framework is no longer needed because they use a destructive prefix of their own to override the default implementation of `MassUtility.CarryCapacity` if the "pawn" in question is a vehicle, therefore the changes made by this transpiler will have no effect for vehicles. See the following references in their repo:
https://github.com/SmashPhil/Vehicle-Framework/blob/master/Source/Vehicles/Harmony/PatchCategories/CaravanHandling.cs#L33-L35
https://github.com/SmashPhil/Vehicle-Framework/blob/master/Source/Vehicles/Harmony/PatchCategories/CaravanHandling.cs#L248-L264